### PR TITLE
Add React DOM router

### DIFF
--- a/web/src/main/kotlin/components/404.kt
+++ b/web/src/main/kotlin/components/404.kt
@@ -1,0 +1,24 @@
+package components
+
+import react.Fragment
+import react.RProps
+import react.child
+import react.dom.div
+import react.functionalComponent
+import react.router.dom.browserRouter
+import react.router.dom.route
+import react.router.dom.switch
+
+@ExperimentalJsExport
+val Error404NotFound = functionalComponent<RProps> {
+    Fragment {
+        div(classes = "container mx-auto p-4 text-gray-500") {
+            div(classes = "mb-3 text-3xl font-semibold") {
+                +"Page not found"
+            }
+            div(classes = "text-sm") {
+                +"We could not find the page you were looking for."
+            }
+        }
+    }
+}

--- a/web/src/main/kotlin/components/app.kt
+++ b/web/src/main/kotlin/components/app.kt
@@ -1,28 +1,22 @@
 package components
 
-import com.mirego.nwad.factories.Bootstrap
-import com.mirego.trikot.streams.cancellable.CancellableManager
-import react.Fragment
 import react.RProps
 import react.child
 import react.dom.div
 import react.functionalComponent
+import react.router.dom.browserRouter
+import react.router.dom.route
+import react.router.dom.switch
 
 @ExperimentalJsExport
 val App = functionalComponent<RProps> {
-    val homeViewModel = Bootstrap.viewModelFactory.homeViewModel(CancellableManager())
-
-    Fragment {
+    browserRouter {
         child(NavBar)
 
-        div(classes = "container mx-auto px-4") {
-            child(labelComponent) {
-                attrs.viewModel = homeViewModel.labelViewModel
-            }
-
-            child(momentsComponent) {
-                attrs.viewModel = homeViewModel.moments
-            }
+        switch {
+            route("/", exact = true) { child(Home) }
+            route("/moments/:momentId") { child(Moment) }
+            route("*") { child(Error404NotFound) }
         }
     }
 }

--- a/web/src/main/kotlin/components/home.kt
+++ b/web/src/main/kotlin/components/home.kt
@@ -1,0 +1,29 @@
+package components
+
+import com.mirego.nwad.factories.Bootstrap
+import com.mirego.trikot.streams.cancellable.CancellableManager
+import react.Fragment
+import react.RProps
+import react.child
+import react.dom.div
+import react.functionalComponent
+import react.router.dom.hashRouter
+import react.router.dom.route
+import react.router.dom.switch
+
+@ExperimentalJsExport
+val Home = functionalComponent<RProps> {
+    val homeViewModel = Bootstrap.viewModelFactory.homeViewModel(CancellableManager())
+
+    Fragment {
+        div(classes = "container mx-auto px-4") {
+            child(labelComponent) {
+                attrs.viewModel = homeViewModel.labelViewModel
+            }
+
+            child(momentsComponent) {
+                attrs.viewModel = homeViewModel.moments
+            }
+        }
+    }
+}

--- a/web/src/main/kotlin/components/moment.kt
+++ b/web/src/main/kotlin/components/moment.kt
@@ -1,0 +1,22 @@
+package components
+
+import react.Fragment
+import react.RProps
+import react.dom.div
+import react.functionalComponent
+import react.router.dom.useParams
+
+external interface MomentParams : RProps {
+    var momentId: String
+}
+
+@ExperimentalJsExport
+val Moment = functionalComponent<RProps> {
+    val momentId = useParams<MomentParams>()?.momentId ?: return@functionalComponent
+
+    Fragment {
+        div(classes = "container mx-auto px-4") {
+            +"Moment $momentId"
+        }
+    }
+}

--- a/web/src/main/kotlin/components/moments.kt
+++ b/web/src/main/kotlin/components/moments.kt
@@ -6,18 +6,24 @@ import com.mirego.trikot.viewmodels.declarative.properties.ImageDescriptor
 import movetotrikot.viewModelComponent
 import react.dom.div
 import react.dom.img
+import react.router.dom.routeLink
 
 val momentsComponent = viewModelComponent<ListViewModel<MomentViewModel>> { moments ->
     div(classes = "container grid grid-flow-row auto-rows-max") {
         for (moment in moments.elements) {
-            div(classes = "pb-4") {
-                +moment.title.text
+            routeLink(
+                to = "/moments/${moment.identifier}",
+                replace = true
+            ) {
+                div(classes = "pb-4") {
+                    +moment.title.text
 
-                div(classes = "relative border-2 rounded p-1") {
-                    img(
-                        classes = "rounded",
-                        src = (moment.image.image as ImageDescriptor.Remote).url
-                    ) {}
+                    div(classes = "relative border-2 rounded p-1") {
+                        img(
+                            classes = "rounded",
+                            src = (moment.image.image as ImageDescriptor.Remote).url
+                        ) {}
+                    }
                 }
             }
         }

--- a/web/src/main/kotlin/main.kt
+++ b/web/src/main/kotlin/main.kt
@@ -3,7 +3,6 @@ import com.mirego.trikot.http.web.WebHttpRequestFactory
 import components.App
 import kotlinext.js.require
 import kotlinx.browser.document
-import react.dom.div
 import react.dom.render
 import react.child
 
@@ -17,9 +16,7 @@ fun main() {
     setupLocalization()
 
     render(document.getElementById("root")) {
-        div {
-            child(App) {}
-        }
+        child(App)
     }
 }
 

--- a/web/src/main/resources/index.html
+++ b/web/src/main/resources/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>web</title>
+    <title>NWAD</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.4.0/font/bootstrap-icons.css">
   </head>
   <body>
     <div id="root"></div>
-    <script src="web.js"></script>
+    <script src="/web.js"></script>
   </body>
 </html>

--- a/web/webpack.config.d/dev-server.js
+++ b/web/webpack.config.d/dev-server.js
@@ -9,6 +9,10 @@ config.devServer.open = false;
 // See https://webpack.js.org/configuration/dev-server/#devserverdisablehostcheck
 config.devServer.disableHostCheck = true;
 
+// Use HTML5 History API instead of serving 404 for known routes
+// See https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback
+config.devServer.historyApiFallback = true;
+
 // Required for Live Reloading to work when navigating in SSL/TLS
 // See https://webpack.js.org/configuration/dev-server/#devserversockhost
 if (process.env.USE_SSL == 'true') {


### PR DESCRIPTION
## 📖 Description

Add Web router to support the future! 

Initial view implemented with no data to reach `/moments/:id` as well as a 404 page for the rest of unknown routes.

## 🎉 Results

![Screen Shot 2021-05-20 at 22 03 50](https://user-images.githubusercontent.com/513491/119071360-ac8ce280-b9b7-11eb-9ea7-8a7e33b69222.png)
![Screen Shot 2021-05-20 at 22 04 03](https://user-images.githubusercontent.com/513491/119071361-ad257900-b9b7-11eb-84e9-c88586e9b9ee.png)


## 🦀 Dispatch

`#dispatch/kmp`
`#dispatch/react`
